### PR TITLE
Balancing.

### DIFF
--- a/code/game/jobs/job/church.dm
+++ b/code/game/jobs/job/church.dm
@@ -207,7 +207,7 @@
 
 	stat_modifiers = list(
 	STAT_VIG = 20,
-	STAT_BIO = 20,
+	STAT_BIO = 30,
 	STAT_TGH = 40,
 	STAT_ROB = 40,
 	)

--- a/code/game/jobs/job/medical.dm
+++ b/code/game/jobs/job/medical.dm
@@ -128,7 +128,7 @@
 		STAT_TGH = 20,
 		STAT_ROB = 20,
 		STAT_VIG = 10,
-		STAT_BIO = 15
+		STAT_BIO = 10
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/chem_catalog,
@@ -171,7 +171,7 @@
 	)
 
 	stat_modifiers = list(
-		STAT_BIO = 25,
+		STAT_BIO = 10,
 		STAT_COG = 15,
 		STAT_VIG = 5
 	)
@@ -221,6 +221,8 @@
 		STAT_TGH = 10,
 		STAT_VIG = 10,
 	)
+
+	perks = list(/datum/perk/timeismoney)
 
 	perks = list(/datum/perk/selfmedicated)
 

--- a/code/game/jobs/job/prospector.dm
+++ b/code/game/jobs/job/prospector.dm
@@ -23,12 +23,15 @@
 	)
 
 	stat_modifiers = list(
-		STAT_ROB = 30,
-		STAT_TGH = 30,
+		STAT_ROB = 40,
+		STAT_TGH = 40,
 		STAT_VIG = 30,
 		STAT_MEC = 10,
 		STAT_BIO = 10,
 	)
+
+	perks = list(/datum/perk/junkborn)
+	perks = list(/datum/perk/space_asshole)
 
 	software_on_spawn = list(/datum/computer_file/program/comm,
 							 /datum/computer_file/program/digitalwarrant,
@@ -75,7 +78,7 @@
 		STAT_BIO = 30,
 		STAT_MEC = 30,
 		STAT_COG = 10,
-		STAT_TGH = 10,
+		STAT_TGH = 20,
 		STAT_VIG = 10,
 		STAT_ROB = 10,
 	)
@@ -117,10 +120,14 @@
 	)
 
 	stat_modifiers = list(
-		STAT_TGH = 20,
+		STAT_TGH = 40,
 		STAT_VIG = 20,
-		STAT_ROB = 20,
+		STAT_ROB = 40,
+		STAT_BIO = 10,
 	)
+
+	perks = list(/datum/perk/junkborn)
+	perks = list(/datum/perk/space_asshole)
 
 	description = "The Prospector serves as hired muscle to the Foreman, positioned somewhere between meat shield and exterminator.<br>\
 	Your job is to keep the Salvagers and anyone else with you protected, handling the fighting and being the first to enter dangerous areas. <br>\

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -289,6 +289,8 @@
 		STAT_ROB = 10,
 	)
 
+	perks = list(/datum/perk/timeismoney)
+
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/suit_sensors,
 							 /datum/computer_file/program/chem_catalog,


### PR DESCRIPTION
## About The Pull Request
<details>
<summary>
	I balanced the stats from some occupations a little bit, and gave them some perks they lacked and other jobs had. Should make them more balanced regarding what they should be doing.
</summary>
<hr>

-Re-balanced the Foreman to make them hardy, given they should have experience with combat and toughing up.
   This job requires a certain level of strength. ROB = 40,
   Manned up and dealt with it. TGH = 40,
   Slight improvement to accuracy. VIG = 30,
   Pre existing stat. MEC = 10,
   Basic first aid training. BIO = 10,

-Re-balanced the Salvager to give them a little more of a chance. field medics need to be a little tough as well. Else, you should stick to the hospital stuff.
   Toughness upped 10 points to make a total of TGH = 20

-Re-balanced the Prospector to make them hardy enough to deal with the dangers they'll face out there. They do need to be their salvager's meat shield. Also gave them some basic first aid training, pretty basic, everyone in their field should get this.
   Upped toughness 20 points to make a total of TGH = 40
   Added some medical skill for a value of BIO = 10

-Re-Balanced both the Corpsman and the Paramedic to be more competent than the psychiatrist when dealing with critical patients until a proper doctor can get their hands on them. Both have a stat of BIO = 30

-Nerfed the Orderly and the psychiatrist. They're not medical medical staff, nor do they have training in the field of medicine (Psychiatrist deal with the mind stuff, not the physical stuff, duh.) Therefore I lowered their medicine to BIO = 10

-Gave the Prospector, Salvager, and Foreman, the Expert Salvager perk, and the Prospector and Foreman get the explosion resistant perk. The Corpsman and the Paramedic get the hyperizine implant.
	
<hr>
</details>

## Changelog
:cl:
Didn't add anything, just changed stuff's value above.
/:cl: