### PR TITLE
Security Loadout Fix

### DIFF
--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -115,7 +115,7 @@
 
 
 /datum/job/supsec
-	title = "Chief Warrant Officer"
+	title = "Warrant Officer"
 	flag = SUPSEC
 	department = DEPARTMENT_SECURITY
 	department_flag = SECURITY
@@ -146,7 +146,7 @@
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/camera_monitor)
 
-	description = "The Chief Warrant Officer is the right hand of the Provost Marshal and the defacto controller of the armory and armory shop. <br>\
+	description = "The Warrant Officer is the right hand of the Provost Marshal and the defacto controller of the armory and armory shop. <br>\
 	Your role is mainly a desk job - with duties rarely taking you outside of the city or even the armory.<br>\
 	You will often be asked to sell weaponry and armory to citizens, maintaining the stock of the equipment and tracking who has what.<br>\
 	You will also be often asked to watch or process prisoners. Perform regular checkups on anyone locked in the brig - breakouts are intolerable.<br>\
@@ -158,7 +158,7 @@
 	Perform training drills and other exercises to bring the Provosts up to standard."
 
 /obj/landmark/join/start/supsec
-	name = "Chief Warrant Officer"
+	name = "Warrant Officer"
 	icon_state = "player-blue"
 	join_tag = /datum/job/supsec
 
@@ -314,7 +314,7 @@
 
 
 /datum/job/trooper
-	title = "Black Guard Trooper"
+	title = "Blackguard Trooper"
 	flag = TROOPER
 	department = DEPARTMENT_SECURITY
 	department_flag = SECURITY
@@ -343,7 +343,7 @@
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/camera_monitor)
 
-	description = "The Trooper forms the base of the Black Guard, the frontline against pirates, terrorists, and xenos.<br>\
+	description = "The Trooper forms the base of the Blackguard, the frontline against pirates, terrorists, and xenos.<br>\
 	You are a professional soldier in service to the Commonwealth. Employ your talents to bring an end to threats and conflict situations.<br>\
 	Tactics and teamwork are vital. You are paid to follow orders, not to think. Remember your focus on external threats - leave otherwise to Provosts.<br>\
 	When there are no standing orders, your ongoing task is to patrol and be on the lookout for threats or problems. Help the Provosts if explicitly asked. <br>\
@@ -356,7 +356,7 @@
 		Obey the law. You are not above it."
 
 /obj/landmark/join/start/trooper
-	name = "Black Guard Trooper"
+	name = "Blackguard Trooper"
 	icon_state = "player-blue"
 	join_tag = /datum/job/trooper
 

--- a/code/game/jobs/job/security.dm
+++ b/code/game/jobs/job/security.dm
@@ -314,7 +314,7 @@
 
 
 /datum/job/trooper
-	title = "Blackguard Trooper"
+	title = "Black Guard Trooper"
 	flag = TROOPER
 	department = DEPARTMENT_SECURITY
 	department_flag = SECURITY
@@ -343,7 +343,7 @@
 	software_on_spawn = list(/datum/computer_file/program/digitalwarrant,
 							 /datum/computer_file/program/camera_monitor)
 
-	description = "The Trooper forms the base of the Blackguard, the frontline against pirates, terrorists, and xenos.<br>\
+	description = "The Trooper forms the base of the Black Guard, the frontline against pirates, terrorists, and xenos.<br>\
 	You are a professional soldier in service to the Commonwealth. Employ your talents to bring an end to threats and conflict situations.<br>\
 	Tactics and teamwork are vital. You are paid to follow orders, not to think. Remember your focus on external threats - leave otherwise to Provosts.<br>\
 	When there are no standing orders, your ongoing task is to patrol and be on the lookout for threats or problems. Help the Provosts if explicitly asked. <br>\
@@ -356,7 +356,7 @@
 		Obey the law. You are not above it."
 
 /obj/landmark/join/start/trooper
-	name = "Blackguard Trooper"
+	name = "Black Guard Trooper"
 	icon_state = "player-blue"
 	join_tag = /datum/job/trooper
 

--- a/code/modules/client/preference_setup/loadout/lists/factionsecurity.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionsecurity.dm
@@ -1,75 +1,75 @@
 /datum/gear/factionsecurity
 	display_name = "winter coat, security"
 	path = /obj/item/clothing/suit/hooded/wintercoat/security
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/beretcommander
 	display_name = "beret, security head"
 	path = /obj/item/clothing/head/rank/commander/beret
-	allowed_roles = list("Blackshield Commander","Warrant Officer")
+	allowed_roles = list("Infantry Commander","Provost Marshal")
 	slot = slot_head
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/beretironhammer
 	display_name = "beret, security"
 	path = /obj/item/clothing/head/rank/ironhammer
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_head
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/beretwarden
-	display_name = "beret, supply specialist"
+	display_name = "beret, Warrant Officer"
 	path = /obj/item/clothing/head/rank/warden/beret
-	allowed_roles = list("Supply Specialist","Sergeant")
+	allowed_roles = list("Warrant Officer","Sergeant Major")
 	slot = slot_head
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/cloak
-	display_name = "cloak, warrant officer"
+	display_name = "cloak, Provost Marshal"
 	path = /obj/item/clothing/suit/hooded/cloak/job/ihc
-	allowed_roles = list("Warrant Officer")
+	allowed_roles = list("Provost Marshal")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/cloakironhammer
 	display_name = "cloak, security"
 	path = /obj/item/clothing/suit/hooded/cloak/job/ironhammer
-	allowed_roles = list("Militia Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/capfield
 	display_name = "cap, field"
 	path = /obj/item/clothing/head/soft/sec2soft
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/cappatrolblack
 	display_name = "cap, patrol black"
 	path = /obj/item/clothing/head/seccorp
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_head
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/cappatrolblue
 	display_name = "cap, patrol blue"
 	path = /obj/item/clothing/head/seccap
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_head
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/capsarge
-	display_name = "cap, supply specialist"
+	display_name = "cap, Warrant Officer"
 	path = /obj/item/clothing/head/soft/sarge2soft
-	allowed_roles = list("Supply Specialist", "Sergeant")
+	allowed_roles = list("Warrant Officer", "Sergeant Major")
 	sort_category = "Faction: Security"
 
 /datum/gear/factionSecurity/gorka_ih
 	display_name = "gorka jacket, security"
 	path = /obj/item/clothing/suit/gorka/toggle/gorka_ih
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
@@ -90,14 +90,14 @@
 /datum/gear/factionsecurity/gorkasecurity
 	display_name = "gorka jumpsuit, security"
 	path = /obj/item/clothing/under/rank/security/gorka_ih
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/gorkasecuritypants
 	display_name = "gorka pants, security"
 	path = /obj/item/clothing/under/rank/security/gorkapantsih
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
@@ -118,7 +118,7 @@
 /datum/gear/factionsecurity/gorka_pants
 	display_name = "gorka security pants"
 	path = /obj/item/clothing/under/rank/security/gorkapantsih
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
@@ -132,14 +132,14 @@
 /datum/gear/factionsecurity/inspector
 	display_name = "uniform, patrol"
 	path = /obj/item/clothing/under/rank/inspector/uniform
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/jumpskirtcommander
 	display_name = "jumpskirt, commander"
 	path = /obj/item/clothing/under/rank/ih_commander/skirt
-	allowed_roles = list("Warrant Officer")
+	allowed_roles = list("Provost Marshal")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
@@ -153,14 +153,14 @@
 /datum/gear/factionsecurity/jumpskirtoperative
 	display_name = "jumpskirt, operative"
 	path = /obj/item/clothing/under/rank/security/skirt
-	allowed_roles = list("Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/jumpskirtwarden
-	display_name = "jumpskirt, supply specialist"
+	display_name = "jumpskirt, Warrant Officer"
 	path = /obj/item/clothing/under/rank/warden/skirt
-	allowed_roles = list("Supply Specialist")
+	allowed_roles = list("Warrant Officer")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
@@ -174,7 +174,7 @@
 /datum/gear/factionsecurity/fatigueselection
 	display_name = "fatigue selection"
 	path = /obj/item/clothing/under/rank/fatigues/
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	flags = GEAR_HAS_TYPE_SELECTION
 	sort_category = "Faction: Security"
@@ -182,7 +182,7 @@
 /datum/gear/factionsecurity/fatiguecoverselection
 	display_name = "fatigue cover selection"
 	path = /obj/item/clothing/head/rank/fatigue/
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_head
 	flags = GEAR_HAS_TYPE_SELECTION
 	sort_category = "Faction: Security"
@@ -190,21 +190,21 @@
 /datum/gear/factionsecurity/snowsuitsecurity
 	display_name = "snowsuit, security"
 	path = /obj/item/clothing/suit/storage/snowsuit/security
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/winterbootssecurity
 	display_name = "winter boots, security"
 	path = /obj/item/clothing/shoes/winter/security
-	allowed_roles = list("Blackshield Commander","Warrant Officer","Supply Specialist","Sergeant","Ranger","Corpsman","Blackshield Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
 	slot = slot_shoes
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/ihcgreatcoat
 	display_name= "greatcoat, commander"
 	path = /obj/item/clothing/suit/greatcoat/ihc
-	allowed_roles = list("Warrant Officer")
+	allowed_roles = list("Infantry Commander","Provost Marshal")
 	slot = slot_wear_suit
 	flags = GEAR_HAS_TYPE_SELECTION
 	sort_category = "Faction: Security"
@@ -212,20 +212,20 @@
 /datum/gear/factionsecurity/ihcgreatcoatblue
 	display_name= "blue greatcoat, commander"
 	path = /obj/item/clothing/suit/greatcoat/ihc_blue
-	allowed_roles = list("Warrant Officer")
+	allowed_roles = list("Infantry Commander","Provost Marshal")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/ihcgreatcoatblue_cloak
 	display_name= "blue cloaked greatcoat, commander"
 	path = /obj/item/clothing/suit/greatcoat/ihc/ihc_coat_cloak
-	allowed_roles = list("Warrant Officer")
+	allowed_roles = list("Infantry Commander","Provost Marshal")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/ihccap
 	display_name= "cap, commander"
 	path = /obj/item/clothing/head/rank/commander/cap
-	allowed_roles = list("Warrant Officer")
+	allowed_roles = list("Infantry Commander")
 	slot = slot_head
 	sort_category = "Faction: Security"

--- a/code/modules/client/preference_setup/loadout/lists/factionsecurity.dm
+++ b/code/modules/client/preference_setup/loadout/lists/factionsecurity.dm
@@ -1,7 +1,7 @@
 /datum/gear/factionsecurity
 	display_name = "winter coat, security"
 	path = /obj/item/clothing/suit/hooded/wintercoat/security
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
@@ -15,7 +15,7 @@
 /datum/gear/factionsecurity/beretironhammer
 	display_name = "beret, security"
 	path = /obj/item/clothing/head/rank/ironhammer
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_head
 	sort_category = "Faction: Security"
 
@@ -36,27 +36,27 @@
 /datum/gear/factionsecurity/cloakironhammer
 	display_name = "cloak, security"
 	path = /obj/item/clothing/suit/hooded/cloak/job/ironhammer
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/capfield
 	display_name = "cap, field"
 	path = /obj/item/clothing/head/soft/sec2soft
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/cappatrolblack
 	display_name = "cap, patrol black"
 	path = /obj/item/clothing/head/seccorp
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_head
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/cappatrolblue
 	display_name = "cap, patrol blue"
 	path = /obj/item/clothing/head/seccap
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_head
 	sort_category = "Faction: Security"
 
@@ -69,7 +69,7 @@
 /datum/gear/factionSecurity/gorka_ih
 	display_name = "gorka jacket, security"
 	path = /obj/item/clothing/suit/gorka/toggle/gorka_ih
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
@@ -90,14 +90,14 @@
 /datum/gear/factionsecurity/gorkasecurity
 	display_name = "gorka jumpsuit, security"
 	path = /obj/item/clothing/under/rank/security/gorka_ih
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/gorkasecuritypants
 	display_name = "gorka pants, security"
 	path = /obj/item/clothing/under/rank/security/gorkapantsih
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
@@ -118,7 +118,7 @@
 /datum/gear/factionsecurity/gorka_pants
 	display_name = "gorka security pants"
 	path = /obj/item/clothing/under/rank/security/gorkapantsih
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
@@ -132,7 +132,7 @@
 /datum/gear/factionsecurity/inspector
 	display_name = "uniform, patrol"
 	path = /obj/item/clothing/under/rank/inspector/uniform
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
@@ -153,7 +153,7 @@
 /datum/gear/factionsecurity/jumpskirtoperative
 	display_name = "jumpskirt, operative"
 	path = /obj/item/clothing/under/rank/security/skirt
-	allowed_roles = list("Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	sort_category = "Faction: Security"
 
@@ -174,7 +174,7 @@
 /datum/gear/factionsecurity/fatigueselection
 	display_name = "fatigue selection"
 	path = /obj/item/clothing/under/rank/fatigues/
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_w_uniform
 	flags = GEAR_HAS_TYPE_SELECTION
 	sort_category = "Faction: Security"
@@ -182,7 +182,7 @@
 /datum/gear/factionsecurity/fatiguecoverselection
 	display_name = "fatigue cover selection"
 	path = /obj/item/clothing/head/rank/fatigue/
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_head
 	flags = GEAR_HAS_TYPE_SELECTION
 	sort_category = "Faction: Security"
@@ -190,14 +190,14 @@
 /datum/gear/factionsecurity/snowsuitsecurity
 	display_name = "snowsuit, security"
 	path = /obj/item/clothing/suit/storage/snowsuit/security
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_wear_suit
 	sort_category = "Faction: Security"
 
 /datum/gear/factionsecurity/winterbootssecurity
 	display_name = "winter boots, security"
 	path = /obj/item/clothing/shoes/winter/security
-	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Blackguard Trooper","Master-at-Arms")
+	allowed_roles = list("Infantry Commander","Provost Marshal","Warrant Officer","Sergeant Major","Corpsman","Black Guard Trooper","Master-at-Arms")
 	slot = slot_shoes
 	sort_category = "Faction: Security"
 


### PR DESCRIPTION
Adjusts job titles slightly.
- Chief Warrant Officer to Warrant Officer

Renames jobs in loadout to new job names, allowing selection in loadout.
- Blackshield/Militia Commander to Infantry Commander
- Warrant Officer to Provost Marshal
- Supply Specialist to Warrant Officer
- Sergeant to Sergeant Major
- Blackshield Trooper to Black Guard Trooper