### PR TITLE
Reverts Addition of Naramad Lance Disk and Datums

### DIFF
--- a/code/datums/autolathe/guns.dm
+++ b/code/datums/autolathe/guns.dm
@@ -308,22 +308,6 @@
 /datum/design/autolathe/gun/dp
 	name= "SA BR . 7.5 \"DP\""
 	build_path = /obj/item/weapon/gun/projectile/automatic/dp
-	
-/datum/design/autolathe/gun/speargun
-	name= "Naramad Shotgun Lance"
-	build_path = /obj/item/weapon/gun/projectile/speargun
-	
-/datum/design/autolathe/gun/protospeargun
-	name= "\"Rain's Fury\" Prototype Naramad Rifle-Lance"
-	build_path = /obj/item/weapon/gun/projectile/speargun/protospeargun
-	
-/datum/design/autolathe/gun/speargunb
-	name= "\"Cleaver\" Naramad Shotgun-Lance"
-	build_path = /obj/item/weapon/gun/projectile/speargun/speargunb
-	
-/datum/design/autolathe/gun/speargunc
-	name= "Naramad Shotgun Lance"
-	build_path = /obj/item/weapon/gun/projectile/speargun/speargunc
 
 //L A U N C H E R S
 

--- a/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
+++ b/code/game/objects/items/weapons/autolathe_disk/guns_ammo_sec_disks.dm
@@ -964,20 +964,3 @@ obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/lenar
 		/datum/design/autolathe/ammo/c10x24,
 		/datum/design/autolathe/ammo/box_10x24 = 2,
 	)
-	
-//SPEARGUNS
-
-/obj/item/weapon/computer_hardware/hard_drive/portable/design/spearguns
-	disk_name = "Naramad Assault Pack"
-	icon_state = "black"
-	license = 12
-	designs = list(
-		/datum/design/autolathe/gun/speargun = 2,
-		/datum/design/autolathe/gun/protospeargun = 6,
-		/datum/design/autolathe/gun/speargunb = 2,
-		/datum/design/autolathe/gun/speargunc = 2,
-		/datum/design/autolathe/ammo/shotgun,
-		/datum/design/autolathe/ammo/shotgun_pellet,
-		/datum/design/autolathe/ammo/shotgun_beanbag,
-		/datum/design/autolathe/ammo/antim = 2,
-	)

--- a/code/game/objects/random/lathe_disks.dm
+++ b/code/game/objects/random/lathe_disks.dm
@@ -121,7 +121,6 @@
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/sa_pk = 1,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/protector = 1,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/lenar = 1,
-				/obj/item/weapon/computer_hardware/hard_drive/portable/design/spearguns = 3,
 
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/counselor = 6,
 				/obj/item/weapon/computer_hardware/hard_drive/portable/design/guns/spiderrose = 4,


### PR DESCRIPTION
There's no good reason why I was getting errors regarding the autolathe datums for the speargun. Better to revert all of these and figure out later. The rest of the old PR should work fine.