### PR TITLE
Maybe Gives German By Default to Kriosans

### DIFF
--- a/code/modules/mob/living/carbon/human/species/species.dm
+++ b/code/modules/mob/living/carbon/human/species/species.dm
@@ -397,3 +397,5 @@
 		H.add_language(LANGUAGE_CHTMANT)
 	if(H.species.reagent_tag == IS_OPIFEX)
 		H.add_language(LANGUAGE_OPIFEXEE)
+	if(H.species.default_form == FORM_KRIOSAN)
+		H.add_language(LANGUAGE_GERMAN)


### PR DESCRIPTION
I have no idea if this will work, so be ready to revert it if it doesn't. I think the language stuff in this file uses the defines on the species file. Kriosans don't have reagent tag like the others above it, so I am going by default form. Will it work? Maybe. 